### PR TITLE
Replace AWS S3 storage with MinIO-compatible Storage class

### DIFF
--- a/app/utils/storage.py
+++ b/app/utils/storage.py
@@ -1,227 +1,70 @@
-"""
-Storage utilities for managing video files on AWS S3.
-"""
 import os
-import json
-import uuid
-import logging
-import datetime
-from pathlib import Path
-from typing import Optional, Dict, Any
+from minio import Minio
+from minio.error import S3Error
+from fastapi import HTTPException, status
+from urllib.parse import urlparse
+from datetime import timedelta
 
-import boto3
-from botocore.exceptions import ClientError
-
-# Configure logging
-logger = logging.getLogger(__name__)
-
-class S3StorageManager:
-    """
-    Class to manage uploads to AWS S3.
-    """
-    _instance = None
-    
-    def __new__(cls):
-        """Singleton pattern to ensure only one S3 instance is created."""
-        if cls._instance is None:
-            cls._instance = super(S3StorageManager, cls).__new__(cls)
-            cls._instance._initialized = False
-        return cls._instance
-    
+class Storage:
     def __init__(self):
-        """Initialize AWS S3 client."""
-        if self._initialized:
-            return
-            
-        try:
-            # Initialize S3 client using environment variables
-            # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_REGION are automatically used by boto3
-            self.s3_client = boto3.client('s3')
-            
-            self.bucket_name = os.getenv("AWS_BUCKET_NAME")
-            
-            # Check if the bucket exists
-            if self.bucket_name:
-                try:
-                    self.s3_client.head_bucket(Bucket=self.bucket_name)
-                    self._initialized = True
-                    logger.info(f"AWS S3 initialized successfully with bucket: {self.bucket_name}")
-                except ClientError as e:
-                    logger.error(f"Failed to access AWS S3 bucket '{self.bucket_name}': {e}")
-                    self._initialized = False
-            else:
-                logger.error("AWS_BUCKET_NAME environment variable is not set")
-                self._initialized = False
-                
-        except Exception as e:
-            logger.error(f"Failed to initialize AWS S3: {e}")
-            self._initialized = False
-    
-    @property
-    def is_initialized(self) -> bool:
-        """Check if S3 is properly initialized."""
-        return self._initialized
-    
-    def reinitialize(self) -> bool:
-        """
-        Attempt to reinitialize the S3 connection.
-        
-        Returns:
-            bool: True if initialization successful, False otherwise
-        """
-        self._initialized = False
-        try:
-            # Initialize S3 client using environment variables
-            self.s3_client = boto3.client('s3')
-            
-            self.bucket_name = os.getenv("AWS_BUCKET_NAME")
-            
-            # Check if the bucket exists
-            if self.bucket_name:
-                try:
-                    self.s3_client.head_bucket(Bucket=self.bucket_name)
-                    self._initialized = True
-                    logger.info(f"AWS S3 reinitialized successfully with bucket: {self.bucket_name}")
-                    return True
-                except ClientError as e:
-                    logger.error(f"Failed to access AWS S3 bucket '{self.bucket_name}' during reinitialization: {e}")
-            else:
-                logger.error("S3 bucket name not set in environment variables")
-        except Exception as e:
-            logger.error(f"Failed to reinitialize AWS S3: {e}")
-            
-        return False
-    
-    def upload_video(self, file_path: str, metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, str]]:
-        """
-        Upload a video file to AWS S3.
-        
-        Args:
-            file_path: Path to the video file
-            metadata: Optional metadata for the file
-            
-        Returns:
-            Dict containing URLs and metadata, or None if upload failed
-        """
-        if not self.is_initialized:
-            logger.error("AWS S3 not initialized, cannot upload")
-            return None
-            
-        if not os.path.exists(file_path):
-            logger.error(f"File not found: {file_path}")
-            return None
-            
-        try:
-            # Generate unique ID for the file
-            file_id = str(uuid.uuid4())
-            file_name = os.path.basename(file_path)
-            
-            # Extract file extension
-            _, file_extension = os.path.splitext(file_name)
-            
-            # Create a storage path - videos/{YYYY-MM-DD}/{uuid}.{ext}
-            today = datetime.datetime.now().strftime('%Y-%m-%d')
-            destination_path = f"videos/{today}/{file_id}{file_extension}"
-            
-            # Set content type
-            content_type = "video/mp4"
-            if file_extension.lower() == ".webm":
-                content_type = "video/webm"
-            elif file_extension.lower() == ".mov":
-                content_type = "video/quicktime"
-            
-            # Convert metadata to fit S3 format if provided
-            s3_metadata = {}
-            if metadata:
-                # S3 metadata keys must be strings and values must be strings
-                for key, value in metadata.items():
-                    s3_metadata[key] = str(value)
-            
-            # Upload to S3
-            with open(file_path, 'rb') as file_data:
-                self.s3_client.upload_fileobj(
-                    file_data,
-                    self.bucket_name,
-                    destination_path,
-                    ExtraArgs={
-                        'ContentType': content_type,
-                        'Metadata': s3_metadata
-                    }
-                )
-            
-            # Generate the public URL
-            region = os.getenv("AWS_REGION", "us-east-1")
-            
-            # Get URL generation method - either direct (if bucket is public) or presigned
-            url_type = os.getenv("S3_URL_TYPE", "direct").lower()
-            
-            if url_type == "presigned":
-                # Generate a presigned URL that expires in 7 days (604800 seconds)
-                try:
-                    public_url = self.s3_client.generate_presigned_url(
-                        'get_object',
-                        Params={
-                            'Bucket': self.bucket_name,
-                            'Key': destination_path
-                        },
-                        ExpiresIn=604800  # 7 days in seconds
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to generate presigned URL: {e}")
-                    # Fall back to direct URL
-                    if region == "us-east-1":
-                        public_url = f"https://{self.bucket_name}.s3.amazonaws.com/{destination_path}"
-                    else:
-                        public_url = f"https://{self.bucket_name}.s3.{region}.amazonaws.com/{destination_path}"
-            else:
-                # Direct URL (works if bucket has public access)
-                if region == "us-east-1":
-                    # Standard endpoint for us-east-1
-                    public_url = f"https://{self.bucket_name}.s3.amazonaws.com/{destination_path}"
-                else:
-                    # Region-specific endpoint
-                    public_url = f"https://{self.bucket_name}.s3.{region}.amazonaws.com/{destination_path}"
-            
-            logger.info(f"Video uploaded successfully to {destination_path}")
-            logger.info(f"Generated URL: {public_url}")
-            
-            # Return URLs and metadata
-            return {
-                "url": public_url,
-                "path": destination_path,
-                "name": file_name,
-                "id": file_id,
-                "uploaded_at": datetime.datetime.now().isoformat()
-            }
-            
-        except Exception as e:
-            logger.error(f"Failed to upload video to AWS S3: {e}")
-            return None
-    
-    def delete_video(self, storage_path: str) -> bool:
-        """
-        Delete a video from AWS S3.
-        
-        Args:
-            storage_path: The path to the object in S3
-            
-        Returns:
-            True if deleted successfully, False otherwise
-        """
-        if not self.is_initialized:
-            logger.error("AWS S3 not initialized, cannot delete")
-            return False
-            
-        try:
-            self.s3_client.delete_object(
-                Bucket=self.bucket_name,
-                Key=storage_path
-            )
-            logger.info(f"Video deleted successfully from {storage_path}")
-            return True
-        except Exception as e:
-            logger.error(f"Failed to delete video from AWS S3: {e}")
-            return False
+        self.client = Minio(
+            endpoint=os.getenv("S3_ENDPOINT_URL").replace("http://", "").replace("https://", ""),
+            access_key=os.getenv("S3_ACCESS_KEY"),
+            secret_key=os.getenv("S3_SECRET_KEY"),
+            secure=False  # Set to True if using https
+        )
+        self.bucket_name = os.getenv("S3_BUCKET_NAME")
+        self.ensure_bucket_exists()
 
-# Global storage manager instance
-storage_manager = S3StorageManager() 
+    def ensure_bucket_exists(self):
+        try:
+            if not self.client.bucket_exists(self.bucket_name):
+                self.client.make_bucket(self.bucket_name)
+        except S3Error as err:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Storage error: {err.message}"
+            )
+
+    def upload_file(self, file_path: str, object_name: str):
+        try:
+            self.client.fput_object(
+                bucket_name=self.bucket_name,
+                object_name=object_name,
+                file_path=file_path,
+            )
+            return self.get_file_url(object_name)
+        except S3Error as err:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Upload error: {err.message}"
+            )
+
+    def get_file_url(self, object_name: str):
+        try:
+            # Generate presigned URL that's valid for 7 days
+            return self.client.presigned_get_object(
+                bucket_name=self.bucket_name,
+                object_name=object_name,
+                expires=timedelta(days=7)
+            )
+        except S3Error as err:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"URL generation error: {err.message}"
+            )
+
+    def delete_file(self, object_name: str):
+        try:
+            self.client.remove_object(
+                bucket_name=self.bucket_name,
+                object_name=object_name
+            )
+        except S3Error as err:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Delete error: {err.message}"
+            )
+
+# Create the storage manager instance
+storage_manager = Storage()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,43 @@
-version: '3'
+version: "3.8"
 
 services:
+  minio:
+    image: quay.io/minio/minio:latest
+    container_name: miniio-media-master-api
+    ports:
+      - "49000:9000"   # MinIO API
+      - "49001:9001"   # MinIO Console
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+
   api:
     build: .
+    container_name: media-master-api
     ports:
-      - "8000:8000"
-    volumes:
-      - ./temp:/app/temp
+      - "48000:8000"
     environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_BUCKET_NAME=${AWS_BUCKET_NAME}
-      - AWS_REGION=${AWS_REGION}
-      - DEBUG=${DEBUG}
-      - LOG_LEVEL=${LOG_LEVEL}
-      - KOKORO_API_URL=http://kokoro-tts:8880/v1/audio/speech
       - API_KEY=${API_KEY}
-    restart: unless-stopped
+      - S3_ENDPOINT_URL=http://minio:9000
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - S3_REGION=${S3_REGION}
     depends_on:
-      - kokoro-tts
-    networks:
-      - app-network
-
-  kokoro-tts:
-    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
-    container_name: kokoro-tts-service
-    environment:
-      - DOWNLOAD_MODEL=true
-    ports:
-      - "8880:8880"  # Map to different host port to avoid conflicts
+      - minio
     restart: unless-stopped
-    networks:
-      - app-network
+
+volumes:
+  minio_data:
 
 networks:
-  app-network:
+  default:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.101.0/24
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,8 @@ openai-whisper
 yt-dlp
 ffmpeg-python==0.2.0
 aiofiles==23.2.1 
+
+minio>=7.0.0
+fastapi>=0.68.0
+uvicorn>=0.15.0
+python-multipart>=0.0.5


### PR DESCRIPTION
Description
This PR refactors the storage system to use MinIO via the official minio Python SDK instead of boto3.
Key changes:

- Added support for S3_ENDPOINT_URL, S3_ACCESS_KEY, S3_SECRET_KEY, and S3_BUCKET_NAME
- Cleaned up and simplified storage operations: upload, delete, and presigned URL generation
- Compatible with local MinIO or any S3-compatible storage
- Removes dependency on AWS-specific SDK (boto3) and credentials

Tested successfully in local Docker + MinIO setup on windows 11 with wsl2



Few notes:

After running `docker-compose up -d --build`

go to minio http://localhost:49001/ 
username and pass from .env

create a bucket and make it public
then go to access-keys and create Create access key
and save

docker compose down. change the below keys bucket name and in .env
S3_ACCESS_KEY=your_access_key
S3_SECRET_KEY=your_secret_key
S3_BUCKET_NAME=media-bucket


save and run docker compose up -d